### PR TITLE
update OpenSSL to latest: OpenSSL_1_1_1t

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt install -y build-essential git cmake python3 python-is-python3 perl vim
 WORKDIR /root
 
 ENV MUMBLE_VERSION=v1.4.287
-ENV OPENSSL_VERSION=OpenSSL_1_1_1-stable
+ENV OPENSSL_VERSION=OpenSSL_1_1_1t
 ENV QT5_VERSION=5.15
 
 # get dependencies to build from source


### PR DESCRIPTION
a patch version of OpenSSL was released (OpenSSL_1_1_1s --> OpenSSL_1_1_1t)

change log: https://github.com/openssl/openssl/blob/OpenSSL_1_1_1t/NEWS
detailed change log: https://github.com/openssl/openssl/blob/OpenSSL_1_1_1t/CHANGES

It seems like they now also use github releases as a release channel: https://github.com/openssl/openssl/releases/tag/OpenSSL_1_1_1t

the versioning scheme is still a non-standard one... (will probably also not change in v1 due to consistency in naming). Need to follow up on this as mentioned: https://github.com/franok/mumble-build-container/issues/5#issuecomment-1402559148