### PR TITLE
building with vcpkg environment (mumble 1.6, Qt6, OpenSSL 3)

### DIFF
--- a/.github/workflows/build-static-murmur-binary.yml
+++ b/.github/workflows/build-static-murmur-binary.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         docker run --rm \
           -v $(pwd)/dist:/root/dist \
-          murmur-build-image cp -rpa /root/mumble/build/. /root/dist/
+          murmur-build-image cp -rpa /dist/. /root/dist/
           
     - name: Upload Build Artifacts
       uses: actions/upload-artifact@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,156 +1,86 @@
-FROM ubuntu:22.04
+# =================================
+# Build Enviroment
+# =================================
 
-RUN apt update
-RUN apt upgrade -y
-RUN apt install -y build-essential git cmake python3 python-is-python3 perl vim 
+FROM ubuntu:24.04 AS build_environment
+RUN apt update && apt install -y wget xz-utils
 
-WORKDIR /root
+ENV MUMBLE_ENVIRONMENT_VERSION=mumble_env.x64-linux.2025-02-27.d7001f6639
 
-ENV MUMBLE_VERSION=v1.4.287
-ENV OPENSSL_VERSION=OpenSSL_1_1_1t
-ENV QT5_VERSION=5.15
+# download pre-built environment
+RUN wget -q -O env.tar.xz "https://github.com/mumble-voip/vcpkg/releases/download/2025-02/$MUMBLE_ENVIRONMENT_VERSION.tar.xz"
 
-# get dependencies to build from source
-RUN git clone https://github.com/mumble-voip/mumble.git mumble --branch ${MUMBLE_VERSION} --single-branch
-RUN git clone https://github.com/openssl/openssl openssl --branch ${OPENSSL_VERSION} --single-branch
-RUN git clone https://github.com/qt/qt5.git qt5 --branch ${QT5_VERSION} --single-branch
-
-# install more dependencies
-
-RUN apt install -y zlib1g-dev
+# extract environment
+RUN tar -xf env.tar.xz
+RUN mv mumble_env.* /mumble-build-environment
 
 
-# build openssl
+# =================================
+# Mumble
+# =================================
+FROM ubuntu:24.04 AS mumble_builder
 
-WORKDIR /root/openssl
-# uname -m
-# well we could also simply use the prebuilt static libssl from libssl-dev on ubuntu ...
-RUN ./Configure no-shared --prefix=/static-prefix  linux-x86_64
-RUN make -j$(nproc)
-RUN make install
+RUN apt update && apt install -y git cmake vim file ninja-build g++-multilib python3
 
+# additional dependencies
+RUN apt-get install -y libdbus-1-dev libsystemd-dev
 
-# now build "the big one" (aka "qt5")
-
-WORKDIR /root/qt5
-
-# only checkout required submodules
-RUN ./init-repository --module-subset=qtbase
-
-ENV MAKEFLAGS="-j 4"
-RUN ./configure -confirm-license -opensource -v \
-	-prefix /static-prefix \ 
-	-plugin-sql-sqlite \
-	-nomake examples \
-	-nomake tests \
-	-skip qt3d \
-	-skip qtactiveqt \
-	-skip qtandroidextras \
-	-skip qtcanvas3d \
-	-skip qtcharts \
-	-skip qtconnectivity \
-	-skip qtdatavis3d \
-	-skip qtdeclarative \
-	-skip qtdoc \
-	-skip qtdocgallery \
-	-skip qtfeedback \
-	-skip qtgamepad \
-	-skip qtgraphicaleffects \
-	-skip qtimageformats \
-	-skip qtlocation \
-	-skip qtlottie \
-	-skip qtmacextras \
-	-skip qtmultimedia \ 
-	-skip qtnetworkauth \
-	-skip qtpim \
-	-skip qtpurchasing \
-	-skip qtqa \
-	-skip qtquick3d \
-	-skip qtquickcontrols \
-	-skip qtquickcontrols2 \
-	-skip qtquicktimeline \
-	-skip qtremoteobjects \
-	-skip qtrepotools \ 
-	-skip qtscript \
-	-skip qtscxml \
-	-skip qtsensors \
-	-skip qtserialbus \
-	-skip qtserialport \
-	-skip qtspeech \
-	-skip qtsvg \
-	-skip qtsystems \
-	-skip qttranslations \
-	-skip qtvirtualkeyboard \
-	-skip qtwayland \
-	-skip qtwebchannel \
-	-skip qtwebengine \
-	-skip qtwebglplugin \
-	-skip qtwebsockets \
-	-skip qtwebview \
-	-skip qtwinextras \
-	-skip qtx11extras \
-	-skip qtxmlpatterns \
-	-no-gui \
-	-no-widgets \
-	-no-dbus \
-	-no-strip \
-	-openssl-linked \
-	-I /static-prefix/include \
-	-L /static-prefix/lib \
-	-static \
-	-no-shared
-
-RUN make -j$(nproc)
-RUN make install
-
-
-# install further dependencies required to compile mumble
-
-RUN apt install -y libprotobuf-dev libcap-dev protobuf-compiler protobuf-c-compiler libboost1.74-dev
-
-
-# build mumble/murmur
-
+# download mumble
+ENV MUMBLE_VERSION=05b4c95b 
+RUN git clone https://github.com/mumble-voip/mumble.git /root/mumble
 WORKDIR /root/mumble
+RUN git checkout $MUMBLE_VERSION
 
+# checkout submodules
 RUN git submodule update --init
 
-RUN apt install -y ninja-build file
-
 RUN mkdir build
+WORKDIR /root/mumble/build 
 
-# add license to build directory, so it is available with the build artifacts
-RUN cp -p LICENSE build/
+COPY --from=build_environment /mumble-build-environment /mumble-build-environment
 
-WORKDIR /root/mumble/build
+# provide libresolv.a in the mumble-build-environment
+# TODO: quite hacky. we should rather find out how to adjust the cmake options
+RUN ln -s /usr/lib/x86_64-linux-gnu/libresolv.a  /mumble-build-environment/installed/x64-linux/lib/libresolv.a
 
-RUN cmake .. -Dserver=ON \
-	-Dclient=OFF \
-	-Dice=OFF \
-	-Dstatic=ON \
-	-Ddbus=OFF \
-	-Dgrpc=OFF \
-	-Dzeroconf=OFF \
-	-Dplugins=OFF \
-	-Doverlay=OFF \
-	-Dtests=OFF \
-	-DCMAKE_SYSTEM_PREFIX_PATH="/static-prefix;/root/static-prefix" \
-	-DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
-	-DCMAKE_C_FLAGS="-static-libgcc -static-libstdc++ -static" \
-	-DCMAKE_CXX_FLAGS="-static-libgcc -static-libstdc++ -static" \
-	-DCMAKE_FIND_LIBRARY_SUFFIXES=".a" \
-	-GNinja
+RUN cmake .. -G Ninja -DCMAKE_UNITY_BUILD=ON \
+        -Dserver=ON \
+        -DCMAKE_BUILD_TYPE=Release \
+        -Dclient=OFF \
+        -Dice=ON \
+        -Dstatic=ON \
+        -Ddbus=OFF \
+        -Dzeroconf=OFF \
+        -Dplugins=OFF \
+        -Doverlay=OFF \
+        -Dtests=OFF \
+        -Dsymbols=OFF \
+        -Denable-postgresql=OFF \
+        -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
+        -DCMAKE_C_FLAGS="-static-libgcc -static-libstdc++ -static" \
+    	-DCMAKE_CXX_FLAGS="-static-libgcc -static-libstdc++ -static" \
+		-DIce_HOME="/mumble-build-environment/installed/x64-linux" \
+        -DCMAKE_FIND_LIBRARY_SUFFIXES=".a" \
+		-DCMAKE_TOOLCHAIN_FILE=/mumble-build-environment/scripts/buildsystems/vcpkg.cmake \
+		-DVCPKG_TARGET_TRIPLET=x64-linux
 
 # replace every .so commandline argument with the static version
-RUN sed -i -e 's/\.so/.a/g' build.ninja
-RUN ninja -v
+# TODO: similar hacky, see note above
+RUN sed -i \
+    -e 's| [^ ]*libdbus-1\.so| /usr/lib/x86_64-linux-gnu/libdbus-1.a|g' \
+    -e 's| [^ ]*libresolv\.so| /usr/lib/x86_64-linux-gnu/libresolv.a /usr/lib/x86_64-linux-gnu/libsystemd.a|g' \
+    build.ninja
+
+RUN cmake --build .
 
 # print file info (expect: "mumble-server: ELF 64-bit LSB executable, x86-64, version 1 (GNU/Linux), statically linked, BuildID[sha1]=2fda729a9d550bf1698d015f0a80684b2a3e1a36, for GNU/Linux 3.2.0, not stripped")
 RUN file mumble-server
+
 # assert: file is statically linked
 RUN ldd ./mumble-server || true
 
-# rename server binary
-RUN mv mumble-server murmur.x86_64
-
-CMD ["bash"]
+# collect files
+RUN mkdir -p /dist && \
+	cp mumble-server /dist/murmur.x86_64 && \
+	cp mumble-server.ini /dist/murmur.ini && \
+	cp /root/mumble/LICENSE /dist/LICENSE


### PR DESCRIPTION
changing the way mumble is built, following the [official documentation for building a static binary](https://github.com/mumble-voip/mumble/blob/master/docs/dev/build-instructions/build_static.md)

- prepared for upcoming mumble v1.6
- Qt6
- OpenSSL 3
- Including so far missing mysql & ice drivers

I've also changed the order of commands in the Dockerfile for optimized build caching